### PR TITLE
Update urdf file and drivers.launch for heading support

### DIFF
--- a/lexus_rx_450h_2019/carma.launch
+++ b/lexus_rx_450h_2019/carma.launch
@@ -17,7 +17,7 @@
 <!--
 	carma.launch
 
-  A the ros launch file for the STOL CAV Prototype ROS Network.
+  The ros launch file for the CARMA ROS Network.
   Launches all the needed ros nodes and sets up the parameter server.
   Also sets up all static transforms used by tf2 within the system.
 
@@ -28,25 +28,21 @@
   pkill -f ros
 -->
 <launch>
-
-  <!-- Set Environment Variables -->
-  <env name="ROS_IP" value="192.168.0.100"/>
-
   <!-- Override Required Paths -->
-  <arg name="CARMA_DIR" default="/opt/carma" doc="The path of the package directory"/>
-  <arg name="PARAM_DIR" default="$(arg CARMA_DIR)/params" doc="Directory of yaml parameter files"/>
-  <arg name="URDF_FILE" default="$(arg CARMA_DIR)/urdf/carma.urdf" doc="Path to the vehicle's URDF file"/>
-  <arg name="DATA_DIR"  default="$(arg CARMA_DIR)/app/mock_data" doc="Directory of driver simulation"/>
-  <arg name="SCRIPTS_DIR" default="$(arg CARMA_DIR)/app/engineering_tools" doc="The directory containing scripts for execution"/>
-  <arg name="LAUNCH_DIR" default="$(arg CARMA_DIR)/app/bin/share/carma" doc="Directory containing additional carma launch files such as driver.launch"/>
-  <arg name="log_config" default="$(arg PARAM_DIR)/log-config.properties" doc="The location of the logging config file"/>
+  <arg name="arealist_path" default="$(find aw_platform)/map/arealist.txt" doc="The path of the package directory"/>
 
   <!-- Startup Drivers With Main CARMA System -->
   <arg name="launch_drivers" default="true" doc="True if drivers are to be launched with the CARMA Platform, overrides mock_drivers arg if false"/>
+
+  <!-- Disable Mock Drivers -->
+  <arg name="mock_drivers" 
+    default=""
+    doc="List of driver node base names which will be launched as mock drivers"
+  />
 
   <!-- Rosbag Flag -->
   <arg name="use_rosbag" default="true" doc="Record a rosbag for the to 26 demo"/>
 
   <!-- Include the detailed launch file and pass in new arguments -->
-  <include file="$(find carma)/carma_src.launch" pass_all_args="true"/>
+  <include file="$(find carma)/launch/carma_src.launch" pass_all_args="true"/>
 </launch>

--- a/lexus_rx_450h_2019/carma.urdf
+++ b/lexus_rx_450h_2019/carma.urdf
@@ -14,9 +14,8 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<!-- Green Cadillac Robot Description File
-    This file defines the static transformations of the CAV platform operating on the green cadillac.
-    These are only example values at this time. This is to test if it works
+<!-- Lexus Robot Description File
+    This file defines the static transformations of the CARMA platform operating on a passanger car.
 -->
 <robot name="vehicle_platform">
 
@@ -31,6 +30,9 @@
 	<link name="radar_rr" />
   <link name="host_vehicle"/> <!-- Bounding box center of vehicle (used in BSM)-->
 	<link name="vehicle_front" />
+	<link name="novatel_gnss" />
+	<link name="novatel_imu" />
+	<link name="ned_heading" />
 
   <!-- Reference Frame Transforms -->
   
@@ -43,7 +45,7 @@
     <origin xyz="3.37 0 -0.3556" rpy="3.14159265359 0 0" />
   </joint>
 
-  <!-- host_vehicle -> vehicle_front Transform vehicle_front is FLU-->
+  <!-- base_link -> vehicle_front Transform vehicle_front is FLU-->
   <joint name="base_link_to_vehicle_front" type="fixed">
 		<parent link="base_link" />
 		<child link="vehicle_front" />
@@ -101,5 +103,24 @@
 		<origin xyz="-0.85 -1.05 0.535" rpy="0 0 -1.992" />
 	</joint>
 
-</robot>
+	<!-- Novatel Fix-->
+  <joint name="base_link_to_novatel" type="fixed">
+		<parent link="base_link" />
+		<child link="novatel_gnss" />
+		<origin xyz="0 0 0" rpy="0 0 0" />
+  </joint>
 
+	<!-- Novatel IMU -->
+  <joint name="base_link_to_novatel_imu" type="fixed">
+		<parent link="base_link" />
+		<child link="novatel_imu" />
+		<origin xyz="0 0 0" rpy="0 0 0" />
+  </joint>
+
+	<!-- Novatel to NED Heading -->
+  <joint name="gnss_to_ned_heading" type="fixed">
+		<parent link="novatel_gnss" />
+		<child link="ned_heading" />
+		<origin xyz="0 0 0" rpy="3.14159265358979323846 0 0" />
+  </joint>
+</robot>

--- a/lexus_rx_450h_2019/drivers.launch
+++ b/lexus_rx_450h_2019/drivers.launch
@@ -59,10 +59,12 @@ If not using simulated drivers they are activated if the respective mock argumen
     <arg name="ip" value="192.168.74.10" />
     <arg name="port" value="2000" />
     <arg name="imu_rate" value="100" />
+    <arg name="frame_id" value="novatel_gnss" />
+    <arg name="imu_frame_id" value="novatel_imu" />
   </include>
 
   <!-- Velodyne Lidar Driver Nodes -->
-  <include unless="$(arg mock_lidar)" file="$(find velodyne_lidar_wrapper)/launch/velodyne_lidar_driver.launch">
+  <include unless="$(arg mock_lidar)" file="$(find velodyne_lidar_driver_wrapper)/launch/velodyne_lidar_driver.launch">
     <arg name="frame_id" value="velodyne"/>
     <arg name="device_ip" value="192.168.1.201"/>
   </include>


### PR DESCRIPTION
This PR updates the urdf and drivers.launch file of the lexus to include the frames needed for heading computations needed for GNSS initialization of NDT. The novatel_gnss frame describes the point where GNSS fixes resolve too. The novatel_imu frame describes the frame of IMU data. The ned_heading frame is the frame in whose orientation relative to NED is the vehicle heading. 