### PR TITLE
update carma.launch to use single map file

### DIFF
--- a/lexus_rx_450h_2019/carma.launch
+++ b/lexus_rx_450h_2019/carma.launch
@@ -30,6 +30,9 @@
 <launch>
   <!-- Override Required Paths -->
   <arg name="arealist_path" default="$(find aw_platform)/map/arealist.txt" doc="The path of the package directory"/>
+   <arg name="load_type" value="noupdate"/>
+   <arg name="single_pcd_path" value="$(find aw_platform)/map/pcd_map.pcd"/>
+  <arg name="area" default="1x1"/>
 
   <!-- Startup Drivers With Main CARMA System -->
   <arg name="launch_drivers" default="true" doc="True if drivers are to be launched with the CARMA Platform, overrides mock_drivers arg if false"/>


### PR DESCRIPTION
Resolves #4 by using single map file loading by default on the lexus. This matches the CARMAPlatform configuration. 

I suggest we squash this merge to get the git history cleaner from the vehicle git account. 