### PR TITLE
Remove outdated IMU config in drivers.launch

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch
@@ -64,7 +64,6 @@ If not using simulated drivers they are activated if the respective mock argumen
   <include if="$(arg novatel_gps_driver)" file="$(find novatel_gps_driver)/launch/novatel_gps_driver_eth.launch">
     <arg name="ip" value="192.168.74.10" />
     <arg name="port" value="2000" />
-    <arg name="imu_rate" value="100" />
     <arg name="frame_id" value="novatel_gnss" />
     <arg name="imu_frame_id" value="novatel_imu" />
   </include>

--- a/lexus_rx_450h_2019/drivers.launch
+++ b/lexus_rx_450h_2019/drivers.launch
@@ -64,7 +64,6 @@ If not using simulated drivers they are activated if the respective mock argumen
   <include if="$(arg novatel_gps_driver)" file="$(find novatel_gps_driver)/launch/novatel_gps_driver_eth.launch">
     <arg name="ip" value="192.168.74.10" />
     <arg name="port" value="2000" />
-    <arg name="imu_rate" value="100" />
     <arg name="frame_id" value="novatel_gnss" />
     <arg name="imu_frame_id" value="novatel_imu" />
   </include>


### PR DESCRIPTION
Parameter changes and novatel refactor have made the imu_rate argument in the launch file obsolete. This PR removes it. This has been tested on the blue lexus and the change was also tested on the ford in a different pr. 