### PR TITLE
Fix lexus can config

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/docker-compose-background.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   web-ui:
-    image: usdotfhwastol/carma-web-ui:latest
+    image: usdotfhwastol/carma-web-ui:3.1.0
     network_mode: host
     container_name: web-ui
     environment:

--- a/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   roscore:
-    image: usdotfhwastol/carma-base:3.0.0
+    image: usdotfhwastol/carma-base:3.1.0
     network_mode: host
     container_name: roscore
     volumes_from:
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:3.0.0
+    image: usdotfhwastol/carma-platform:3.1.0
     network_mode: host
     container_name: platform
     volumes_from:
@@ -46,7 +46,7 @@ services:
     command: wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch
 
   cohda_dsrc_driver:
-    image: usdotfhwastol/carma-cohda-dsrc-driver:1.0.0
+    image: usdotfhwastol/carma-cohda-dsrc-driver:1.1.0
     container_name: carma-cohda-dsrc-driver
     network_mode: host
     volumes_from:
@@ -59,7 +59,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=dsrc_driver'
 
   ssc_controller_driver:
-    image: usdotfhwastol/carma-ssc-interface-wrapper:1.0.0
+    image: usdotfhwastol/carma-ssc-interface-wrapper:1.1.0
     container_name: ssc_controller_driver
     network_mode: host
     volumes_from:
@@ -73,7 +73,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=ssc_interface_wrapper'
 
   novatel_gnss_imu_driver:
-    image: usdotfhwastol/carma-novatel-gps-driver:1.0.0
+    image: usdotfhwastol/carma-novatel-gps-driver:3.9.0
     container_name: novatel-gnss-imu-driver
     network_mode: host
     volumes_from:

--- a/ford_fusion_sehybrid_2019/docker-compose-background.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   web-ui:
-    image: usdotfhwastol/carma-web-ui:latest
+    image: usdotfhwastol/carma-web-ui:3.1.0
     network_mode: host
     container_name: web-ui
     environment:

--- a/ford_fusion_sehybrid_2019/docker-compose.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   roscore:
-    image: usdotfhwastol/carma-base:latest
+    image: usdotfhwastol/carma-base:3.1.0
     network_mode: host
     container_name: roscore
     volumes_from:
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastol/carma-platform:3.1.0
     network_mode: host
     container_name: platform
     volumes_from:
@@ -46,7 +46,7 @@ services:
     command: wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch
 
   cohda_dsrc_driver:
-    image: usdotfhwastol/carma-cohda-dsrc-driver:latest
+    image: usdotfhwastol/carma-cohda-dsrc-driver:1.1.0
     container_name: carma-cohda-dsrc-driver
     network_mode: host
     volumes_from:
@@ -59,7 +59,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=dsrc_driver'
 
   ssc_controller_driver:
-    image: usdotfhwastol/carma-ssc-interface-wrapper:latest
+    image: usdotfhwastol/carma-ssc-interface-wrapper:1.1.0
     container_name: ssc_controller_driver
     network_mode: host
     privileged: true # Grant access to usb for can data
@@ -76,7 +76,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=ssc_interface_wrapper'
 
   novatel_gnss_imu_driver:
-    image: usdotfhwastol/carma-novatel-gps-driver:latest
+    image: usdotfhwastol/carma-novatel-gps-driver:3.9.0
     container_name: novatel-gnss-imu-driver
     network_mode: host
     volumes_from:
@@ -89,7 +89,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=novatel_gps_driver'
 
   velodyne_lidar_driver:
-    image: usdotfhwastol/carma-velodyne-lidar-driver:latest
+    image: usdotfhwastol/carma-velodyne-lidar-driver:1.0.0
     container_name: velodyne-lidar-driver
     network_mode: host
     volumes_from:

--- a/lexus_rx_450h_2019/docker-compose-background.yml
+++ b/lexus_rx_450h_2019/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   web-ui:
-    image: usdotfhwastol/carma-web-ui:3.0.0
+    image: usdotfhwastol/carma-web-ui:latest
     network_mode: host
     container_name: web-ui
     environment:

--- a/lexus_rx_450h_2019/docker-compose-background.yml
+++ b/lexus_rx_450h_2019/docker-compose-background.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   web-ui:
-    image: usdotfhwastol/carma-web-ui:latest
+    image: usdotfhwastol/carma-web-ui:3.1.0
     network_mode: host
     container_name: web-ui
     environment:

--- a/lexus_rx_450h_2019/docker-compose.yml
+++ b/lexus_rx_450h_2019/docker-compose.yml
@@ -1,11 +1,11 @@
 #  Copyright (C) 2018-2019 LEIDOS.
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
 #  the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -17,10 +17,10 @@ version: '2'
 
 services:
   roscore:
-    image: usdotfhwastol/carma-base:3.0.0
+    image: usdotfhwastol/carma-base:latest
     network_mode: host
     container_name: roscore
-    volumes_from: 
+    volumes_from:
       - container:carma-config:ro
     environment:
       - ROS_IP=192.168.0.100
@@ -28,12 +28,12 @@ services:
       - /opt/carma/.ros:/home/carma/.ros
     restart: always
     command: roscore
-    
+
   platform:
-    image: usdotfhwastol/carma-platform:3.0.0
+    image: usdotfhwastol/carma-platform:latest
     network_mode: host
     container_name: platform
-    volumes_from: 
+    volumes_from:
       - container:carma-config:ro
     environment:
       - ROS_IP=192.168.0.100
@@ -46,61 +46,57 @@ services:
     command: wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch
 
   cohda_dsrc_driver:
-    image: usdotfhwastol/carma-cohda-dsrc-driver:1.0.0
+    image: usdotfhwastol/carma-cohda-dsrc-driver:latest
     container_name: carma-cohda-dsrc-driver
     network_mode: host
-    volumes_from: 
+    volumes_from:
       - container:carma-config:ro
     environment:
       - ROS_IP=192.168.0.100
-      - ROS_NAMESPACE=hardware_interface
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
-    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch drivers.launch drivers:=dsrc_driver'
+    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=dsrc_driver'
 
-  pacmod_controller_driver:
-    image: usdotfhwastol/carma-pacmod-controller-driver:1.0.0
-    container_name: carma-pacmod-controller-driver
+  ssc_controller_driver:
+    image: usdotfhwastol/carma-ssc-interface-wrapper:latest
+    container_name: ssc_controller_driver
     network_mode: host
-    volumes_from: 
+    volumes_from:
       - container:carma-config:ro
     environment:
       - ROS_IP=192.168.0.100
-      - ROS_NAMESPACE=hardware_interface
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
       - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
-    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch drivers.launch drivers:=ssc_interface_wrapper'
+    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=ssc_interface_wrapper'
 
   novatel_gnss_imu_driver:
-    image: usdotfhwastol/novatel-gnss-imu-driver:1.0.0
+    image: usdotfhwastol/carma-novatel-gps-driver:latest
     container_name: novatel-gnss-imu-driver
     network_mode: host
-    volumes_from: 
+    volumes_from:
       - container:carma-config:ro
     environment:
       - ROS_IP=192.168.0.100
-      - ROS_NAMESPACE=hardware_interface
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
-    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch drivers.launch drivers:=novatel_gps_driver'
-  
+    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=novatel_gps_driver'
+
   velodyne_lidar_driver:
-    image: usdotfhwastol/velodyne-lidar-driver:1.0.0
+    image: usdotfhwastol/carma-velodyne-lidar-driver:latest
     container_name: velodyne-lidar-driver
     network_mode: host
-    volumes_from: 
+    volumes_from:
       - container:carma-config:ro
     environment:
       - ROS_IP=192.168.0.100
-      - ROS_NAMESPACE=hardware_interface
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
-    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch drivers.launch drivers:=velodyne_lidar_wrapper'
+    command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=velodyne_lidar_driver_wrapper'
 
   # TODO AVT Vimba Camera Left Driver Node
   # TODO AVT Vimba Camera Right Driver Node

--- a/lexus_rx_450h_2019/docker-compose.yml
+++ b/lexus_rx_450h_2019/docker-compose.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   roscore:
-    image: usdotfhwastol/carma-base:latest
+    image: usdotfhwastol/carma-base:3.1.0
     network_mode: host
     container_name: roscore
     volumes_from:
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastol/carma-platform:3.1.0
     network_mode: host
     container_name: platform
     volumes_from:
@@ -46,7 +46,7 @@ services:
     command: wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch
 
   cohda_dsrc_driver:
-    image: usdotfhwastol/carma-cohda-dsrc-driver:latest
+    image: usdotfhwastol/carma-cohda-dsrc-driver:1.1.0
     container_name: carma-cohda-dsrc-driver
     network_mode: host
     volumes_from:
@@ -59,7 +59,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=dsrc_driver'
 
   ssc_controller_driver:
-    image: usdotfhwastol/carma-ssc-interface-wrapper:latest
+    image: usdotfhwastol/carma-ssc-interface-wrapper:1.1.0
     container_name: ssc_controller_driver
     network_mode: host
     volumes_from:
@@ -73,7 +73,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=ssc_interface_wrapper'
 
   novatel_gnss_imu_driver:
-    image: usdotfhwastol/carma-novatel-gps-driver:latest
+    image: usdotfhwastol/carma-novatel-gps-driver:3.9.0
     container_name: novatel-gnss-imu-driver
     network_mode: host
     volumes_from:
@@ -86,7 +86,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch drivers:=novatel_gps_driver'
 
   velodyne_lidar_driver:
-    image: usdotfhwastol/carma-velodyne-lidar-driver:latest
+    image: usdotfhwastol/carma-velodyne-lidar-driver:1.0.0
     container_name: velodyne-lidar-driver
     network_mode: host
     volumes_from:

--- a/lexus_rx_450h_2019/drivers.launch
+++ b/lexus_rx_450h_2019/drivers.launch
@@ -54,10 +54,10 @@ If not using simulated drivers they are activated if the respective mock argumen
   <!-- PACMOD Controller Driver Node -->
   <include if="$(arg ssc_interface_wrapper)" file="$(find ssc_interface_wrapper)/launch/ssc_pacmod_driver.launch">
     <arg name="pacmod_vehicle_type" default="LEXUS_RX_450H" />
-    <arg name="use_kvaser" default="true" />
-    <arg name="kvaser_hardware_id" default="10376" />
-    <arg name="kvaser_circuit_id" default="0" />
-    <arg name="ssc_param_dir" value="$(arg vehicle_calibration_dir)"/>
+    <arg name="use_kvaser" default="false" />
+    <arg name="use_socketcan" default="true" />
+    <arg name="socketcan_device" default="can0" />
+    <arg name="ssc_param_dir" value="$(arg vehicle_calibration_dir)/ssc_pm_lexus"/>
   </include>
 
   <!-- Novatel GNSS/IMU Driver Nodes -->


### PR DESCRIPTION
Due to issue usdot-fhwa-stol/CARMAPlatform#350 the lexus configuration had to be switched to use socketcan to communicate with the pacmod controller

This PR also updates the compose version numbers to the ones which will be used in the next release. 