### PR TITLE
updated CARMAPlatform Docker image versions to 3.2.0

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:testarossa
+    image: usdotfhwastol/carma-platform:3.2.0
     network_mode: host
     container_name: platform
     volumes_from:

--- a/ford_fusion_sehybrid_2019/docker-compose.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:testarossa
+    image: usdotfhwastol/carma-platform:3.2.0
     network_mode: host
     container_name: platform
     volumes_from:

--- a/lexus_rx_450h_2019/docker-compose.yml
+++ b/lexus_rx_450h_2019/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:testarossa
+    image: usdotfhwastol/carma-platform:3.2.0
     network_mode: host
     container_name: platform
     volumes_from:


### PR DESCRIPTION
For release testarossa, moving with the docker component release and system release. 