### PR TITLE
Fix wheel base dimension on pacifica

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
@@ -24,7 +24,7 @@ vehicle_height: 2.0
 
 # Double: Distance from front axel to rear axel
 # Units: Meters
-vehicle_wheel_base: 2.85
+vehicle_wheel_base: 3.09
 
 # Double: Radius of the tires
 # Units: Meters


### PR DESCRIPTION
The pacifica had an incorrect wheel_base value set in its configuration file. This should help address 
usdot-fhwa-stol/CARMAPlatform#333

This value was verified by comparing it with the pacficia ssc json file in VehicelCalibration. 