### PR TITLE
Updated wheel_base to match ssc parameter

### DIFF
--- a/freightliner_cascadia_2012/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012/VehicleConfigParams.yaml
@@ -27,7 +27,7 @@ vehicle_height: 3.0
 
 # Double: Distance from front axel to rear axel
 # Units: Meters
-vehicle_wheel_base: 4.525
+vehicle_wheel_base: 5.334
 
 # Double: Radius of the tires
 # Units: Meters


### PR DESCRIPTION
Updated the wheel_base value used by carma to match the value used by the SSC found here
https://github.com/usdot-fhwa-stol/CARMAVehicleCalibration/blob/develop/2012-freightliner_cascadia-DOT_10003/vehicle/calibration/ssc_pm_cascadia/json/steering_model.json

Resolves usdot-fhwa-stol/CARMAPlatform#568

