### PR TITLE
Add shutdown node to drivers launch file

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch
@@ -24,6 +24,10 @@ If not using simulated drivers they are activated if the respective mock argumen
 -->
 
 <launch>
+
+  <!-- Shutdown node to shutsdown driver node with fatal message -->
+  <node pkg="driver_shutdown" type="driver_shutdown" name="$(anon driver_shutdown)" required="true"/>
+
   <arg name="vehicle_calibration_dir" default="/opt/carma/vehicle/calibration" doc="Folder containing vehicle calibration directories"/>
   
   <!-- Simulation Usage -->

--- a/development/drivers.launch
+++ b/development/drivers.launch
@@ -24,8 +24,8 @@ If not using simulated drivers they are activated if the respective mock argumen
 -->
 
 <launch>
-  <node pkg="driver_shutdown" type="driver_shutdown" name="driver_shutdown" required="true"/>
   <arg name="mock_drivers" default="controller can comms gnss radar lidar camera roadway_sensor" />
   <arg name="vehicle_calibration_dir" default="$(arg vehicle_calibration_dir)"/>
   <!-- File not used in development environment where only mock drivers are used -->
+
 </launch>

--- a/development/drivers.launch
+++ b/development/drivers.launch
@@ -24,6 +24,7 @@ If not using simulated drivers they are activated if the respective mock argumen
 -->
 
 <launch>
+  <node pkg="driver_shutdown" type="driver_shutdown" name="driver_shutdown" required="true"/>
   <arg name="mock_drivers" default="controller can comms gnss radar lidar camera roadway_sensor" />
   <arg name="vehicle_calibration_dir" default="$(arg vehicle_calibration_dir)"/>
   <!-- File not used in development environment where only mock drivers are used -->

--- a/ford_fusion_sehybrid_2019/drivers.launch
+++ b/ford_fusion_sehybrid_2019/drivers.launch
@@ -25,6 +25,9 @@ If not using simulated drivers they are activated if the respective mock argumen
 
 <launch>
 
+  <!-- Shutdown node to shutsdown driver node with fatal message -->
+  <node pkg="driver_shutdown" type="driver_shutdown" name="$(anon driver_shutdown)" required="true"/>
+
   <arg name="vehicle_calibration_dir" default="/opt/carma/vehicle/calibration" doc="Folder containing vehicle calibration directories"/>
 
   <!-- Mock Drivers -->

--- a/freightliner_cascadia_2012/drivers.launch
+++ b/freightliner_cascadia_2012/drivers.launch
@@ -24,6 +24,10 @@ If not using simulated drivers they are activated if the respective mock argumen
 -->
 
 <launch>
+  
+  <!-- Shutdown node to shutsdown driver node with fatal message -->
+  <node pkg="driver_shutdown" type="driver_shutdown" name="$(anon driver_shutdown)" required="true"/>
+  
   <arg name="vehicle_calibration_dir" default="/opt/carma/vehicle/calibration" doc="Folder containing vehicle calibration directories"/>
 
   <!-- Mock Drivers -->

--- a/lexus_rx_450h_2019/drivers.launch
+++ b/lexus_rx_450h_2019/drivers.launch
@@ -24,6 +24,10 @@ If not using simulated drivers they are activated if the respective mock argumen
 -->
 
 <launch>
+  
+  <!-- Shutdown node to shutsdown driver node with fatal message -->
+  <node pkg="driver_shutdown" type="driver_shutdown" name="$(anon driver_shutdown)" required="true"/>
+
   <arg name="vehicle_calibration_dir" default="/opt/carma/vehicle/calibration" doc="Folder containing vehicle calibration directories"/>
 
   <!-- Mock Drivers -->


### PR DESCRIPTION
The driver shutdown node is added to vehicles drivers.launch file. This node will shutdown the driver nodes when a fatal system alert is received.
Addressing usdot-fhwa-stol/CARMAPlatform#460